### PR TITLE
Update required hydrogen.provider version to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "consumedServices": {
     "hydrogen.provider": {
       "versions": {
-        "^0.0.3": "consumeHydrogen"
+        "^1.0.0": "consumeHydrogen"
       }
     }
   },
@@ -23,8 +23,7 @@
   "scripts": {
     "lint": "eslint ."
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "package-deps": [
     "hydrogen"
   ],


### PR DESCRIPTION
The example described in the Hydrogen plugin api README was failing due to the required version in package.json. This fixes the issue.